### PR TITLE
Fix: single quoted html attributes are incorrectly parsed by prescribe/postscribe 

### DIFF
--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -4,7 +4,41 @@ export function writeAdHtml(markup, ps = postscribe) {
     // remove <?xml> and <!doctype> tags
     // https://github.com/prebid/prebid-universal-creative/issues/134
     markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/gi, '');
+
+    try {
+        markup = normalizeMarkup(markup);
+    } catch (error) {
+        console.error("Error normalizing markup:", error.message);
+    }
+
     ps(document.body, markup, {
         error: console.error
     });
+}
+
+/**
+ * Normalizes an HTML string by parsing and re-serializing it,
+ * returning the content between custom PUC_START and PUC_END markers.
+ *
+ * This function is specifically aimed at addressing an issue with `postscribe` where double quotes inside single-quoted
+ * HTML attributes are not correctly escaped.
+ */
+ function normalizeMarkup(markup) {
+    const startMarker = '<div id="PUC_START"></div>';
+    const endMarker = '<div id="PUC_END"></div>';
+
+    const wrapped = `${startMarker}${markup}${endMarker}`;
+
+    const doc = new DOMParser().parseFromString(wrapped, "text/html");
+    const serialized = new XMLSerializer().serializeToString(doc);
+
+    const startIndex = serialized.indexOf(startMarker);
+    const endIndex = serialized.indexOf(endMarker, startIndex);
+
+    if (startIndex === -1 || endIndex === -1) {
+        throw new Error("PUC markers not found in serialized output");
+    }
+
+    const snippet = serialized.substring(startIndex + startMarker.length, endIndex);
+    return snippet.trim();
 }

--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -5,13 +5,16 @@ export function writeAdHtml(markup, ps = postscribe) {
     // https://github.com/prebid/prebid-universal-creative/issues/134
     markup = markup.replace(/\<(\?xml|(\!DOCTYPE[^\>\[]+(\[[^\]]+)?))+[^>]+\>/gi, '');
 
+    let finalMarkup;
+
     try {
-        markup = normalizeMarkup(markup);
+        finalMarkup = normalizeMarkup(markup);
     } catch (error) {
         console.error("Error normalizing markup:", error.message);
+        finalMarkup = markup;
     }
 
-    ps(document.body, markup, {
+    ps(document.body, finalMarkup, {
         error: console.error
     });
 }
@@ -24,8 +27,9 @@ export function writeAdHtml(markup, ps = postscribe) {
  * HTML attributes are not correctly escaped.
  */
  function normalizeMarkup(markup) {
-    const startMarker = '<div id="PUC_START"></div>';
-    const endMarker = '<div id="PUC_END"></div>';
+    const timestamp = Date.now();
+    const startMarker = `<div id="PUC_START_${timestamp}"></div>`;
+    const endMarker = `<div id="PUC_END_${timestamp}"></div>`;
 
     const wrapped = `${startMarker}${markup}${endMarker}`;
 
@@ -38,6 +42,8 @@ export function writeAdHtml(markup, ps = postscribe) {
     if (startIndex === -1 || endIndex === -1) {
         throw new Error("PUC markers not found in serialized output");
     }
+
+    console.log('Testing:' + serialized);
 
     const snippet = serialized.substring(startIndex + startMarker.length, endIndex);
     return snippet.trim();

--- a/src/postscribeRender.js
+++ b/src/postscribeRender.js
@@ -28,8 +28,10 @@ export function writeAdHtml(markup, ps = postscribe) {
  */
 function normalizeMarkup(markup) {
     const timestamp = Date.now();
-    const startMarker = `<div id="PUC_START_${timestamp}"></div>`;
-    const endMarker = `<div id="PUC_END_${timestamp}"></div>`;
+    const startMarkerId = `PUC_START_${timestamp}`;
+    const endMarkerId = `PUC_END_${timestamp}`;
+    const startMarker = `<div id="${startMarkerId}"></div>`;
+    const endMarker = `<div id="${endMarkerId}"></div>`;
     const doc = new DOMParser().parseFromString(`${startMarker}${markup}${endMarker}`, "text/html");
 
     const textMap = new Map();
@@ -37,7 +39,7 @@ function normalizeMarkup(markup) {
 
     const replaceTextNodes = (node) => {
         if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-            const id = `__TEXT_${textId++}__`;
+            const id = `PUC_NODE_TEXT_${textId++}_${timestamp}`;
             textMap.set(id, node.textContent);
             const span = doc.createElement("span");
             span.dataset.textId = id;
@@ -47,8 +49,8 @@ function normalizeMarkup(markup) {
         }
     };
 
-    let current = doc.querySelector(`#PUC_START_${timestamp}`).nextSibling;
-    const end = doc.querySelector(`#PUC_END_${timestamp}`);
+    let current = doc.querySelector(`#${startMarkerId}`).nextSibling;
+    const end = doc.querySelector(`#${endMarkerId}`);
     while (current && current !== end) {
         replaceTextNodes(current);
         current = current.nextSibling;
@@ -59,7 +61,7 @@ function normalizeMarkup(markup) {
         .split(startMarker)[1]
         .split(endMarker)[0]
         .replace(
-            /<span data-text-id="(__TEXT_\d+__)"[^>]*><\/span>/g,
+            /<span data-text-id="(PUC_NODE_TEXT_\d+_\d+)"[^>]*><\/span>/g,
             (_, id) => textMap.get(id) || ""
         );
 

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -2,7 +2,9 @@ import { renderAmpOrMobileAd } from 'src/mobileAndAmpRender';
 import * as postscribeRender from 'src/postscribeRender'
 import * as utils from 'src/utils';
 import { expect } from 'chai';
-import {writeAdHtml} from 'src/postscribeRender';
+import { mocks } from 'test/helpers/mocks';
+import { merge } from 'lodash';
+import { writeAdHtml } from 'src/postscribeRender';
 
 
 describe("renderingManager", function () {
@@ -245,5 +247,40 @@ describe('writeAdHtml', () => {
     const markup = '<script>window.testScriptExecuted=true;</script>'
     writeAdHtml(markup);
     expect(window.testScriptExecuted).to.equal(true);
+  });
+
+  it('should handle single quotes with inner double quotes', () => {
+    const input = `<img title='uh "oh" > this should all be inside the title attribute'>`;
+    console.log('Input: ', input);
+
+    writeAdHtml(input);
+
+    const img = document.querySelector('img:last-of-type');
+    if (img) {
+      console.log('Output:', img.outerHTML);
+      console.log('Title: ', img.getAttribute('title'));
+
+      const expected = 'uh "oh" > this should all be inside the title attribute';
+      expect(img.getAttribute('title')).to.equal(expected);
+    }
+  });
+
+  it('should handle JSON in data attributes with single quotes', () => {
+    const input = `<div data-json='{"key": "value"}'>Test</div>`;
+    console.log('Input: ', input);
+
+    writeAdHtml(input);
+
+    const div = document.querySelector('div[data-json]:last-of-type');
+    if (div) {
+      console.log('Output:', div.outerHTML);
+      console.log('Data:  ', div.getAttribute('data-json'));
+
+      const dataJson = div.getAttribute('data-json');
+      expect(dataJson).to.equal('{"key": "value"}');
+
+      const parsed = JSON.parse(dataJson);
+      expect(parsed.key).to.equal('value');
+    }
   });
 })

--- a/test/spec/mobileAndAmpRender_spec.js
+++ b/test/spec/mobileAndAmpRender_spec.js
@@ -2,8 +2,6 @@ import { renderAmpOrMobileAd } from 'src/mobileAndAmpRender';
 import * as postscribeRender from 'src/postscribeRender'
 import * as utils from 'src/utils';
 import { expect } from 'chai';
-import { mocks } from 'test/helpers/mocks';
-import { merge } from 'lodash';
 import { writeAdHtml } from 'src/postscribeRender';
 
 


### PR DESCRIPTION

| Initial | With Fix |
|------------|---------|
| ![Without Fix](https://github.com/user-attachments/assets/e6845c0b-9113-4769-b63f-4190d6b9be85) | ![With Fix](https://github.com/user-attachments/assets/5287c690-a85c-4874-8b56-cfbed8c57582) |
| ![Without Fix](https://github.com/user-attachments/assets/2fce693d-ed24-430f-bfb5-5cae7be87e1e) | ![With Fix](https://github.com/user-attachments/assets/486037d1-ce67-4d46-95d8-afc0d06b9dd3) |
